### PR TITLE
Little fix to avoid errors in agent

### DIFF
--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -1348,8 +1348,23 @@ sub dirlistfm
 		 $size, $atime, $mtime, $ctime, $blksize, $blocks
 		) = stat($_);
 		
-		$uid = getpwuid($uid);
-		$gid = getgrgid($gid);
+		if(defined $uid)
+		{
+			$uid = getpwuid($uid);
+		}
+		else
+		{
+			$uid = '';
+		}
+		
+		if(defined $gid)
+		{
+			$gid = getgrgid($gid);
+		}
+		else
+		{
+			$gid = '';
+		}
 
 		#This if else logic determines what it is, File, Directory, other	
 		if (-T $_)


### PR DESCRIPTION
Fixes the next errors:
Use of uninitialized value $uid in getpwuid at /usr/share/ogp_agent/ogp_agent.pl line 1351.
Use of uninitialized value $gid in getgrgid at /usr/share/ogp_agent/ogp_agent.pl line 1352.